### PR TITLE
runlim.c: fix some missing options in switch

### DIFF
--- a/runlim.c
+++ b/runlim.c
@@ -1284,6 +1284,7 @@ main (int argc, char **argv)
 		tmp_name = argv[i];
 	        break;
 
+	      case 'r':
 	      case 's':
 	      case 't':
 	        i++;
@@ -1293,6 +1294,7 @@ main (int argc, char **argv)
 	      case 'h':
 	      case 'k':
 	      case 'p':
+	      case 'v':
 	        continue;
 
 	      case '-':


### PR DESCRIPTION
'r' and 'v' are currently not handled by the switch, causing this code to attempt opening a log file (with NULL name) when invoked as `runlim -r` or `runlim -v`.