### PR TITLE
flush_inactive: only consider descendants of child_pid

### DIFF
--- a/runlim.c
+++ b/runlim.c
@@ -862,6 +862,19 @@ static double accumulated_time;
 
 /*------------------------------------------------------------------------*/
 
+/* returns 1 iff p is a (direct or indirect) descendant of the child process */
+static int
+in_tree (Process *p)
+{
+  for (; p != NULL; p = p->parent)
+    {
+      if (p->pid == child_pid)
+        return 1;
+    }
+
+  return 0;
+}
+
 static long
 flush_inactive_processes (void)
 {
@@ -889,8 +902,11 @@ flush_inactive_processes (void)
 	  else
 	    active_processes = next;
 
-	  debug ("deactive", "%d (%.3f sec)", p->pid, p->time);
-	  accumulated_time += p->time;
+	  if (in_tree(p)) {
+	    debug ("deactive", "%d (%.3f sec)", p->pid, p->time);
+	    accumulated_time += p->time;
+	  }
+
 	  p->next_process = 0;
 	  res++;
 	}


### PR DESCRIPTION
Hello, I've noticed that runlim would sometimes wildly exaggerate the CPU time used by a process, especially when running parallel measurements. I tracked it down to this: `flush_inactive_processes` is accumulating the runtime for every process that finishes, but it is not checking that they are descendants of the current invocation. Hence any other process in the system that happens to terminate will be counted.

A way to see the problem is by running this loop:
```
while :; do runlim sleep 1; done |& grep 'time:'
```
which will consistently print 0s as the CPU time, and run something else in parallel that runs long enough to be measures. This C program will do:
```c
int main() {
	int i = 1 << 26;
	while (i--);
}
```
Then, the CPU time for the sleep invocations will be higher, about 0.6s in my setup.

I'm not sure this walk to the root is the best way to do it, maybe 1) it can just be cached in the `Process` structure whether a process is a descendant of the child_pid, or 2) maybe `flush_inactive_processes` could recursively traverse the tree and "enable" the accumulation when it find `child_pid`.
